### PR TITLE
bug #44: exit session in case of failure of core.

### DIFF
--- a/src/grpc_webrtc_bridge/grpc_client.py
+++ b/src/grpc_webrtc_bridge/grpc_client.py
@@ -65,9 +65,9 @@ class GRPCClient:
 
     # Got Reachy(s) description
     async def get_reachy(self) -> reachy_pb2.Reachy:
-        # return self.reachy_stub_synchro.GetReachy(Empty())
-        self.logger.info("Getting Reachy")
+        self.logger.info("Getting Reachy ...")
         try:
+            # this is the first call to the grpc server. Core may be still booting up
             return await self.reachy_stub_async.GetReachy(Empty(), timeout=20, wait_for_ready=True)
         except grpc.RpcError as e:
             self.logger.error(f"Error while getting Reachy: {e}")

--- a/src/grpc_webrtc_bridge/server.py
+++ b/src/grpc_webrtc_bridge/server.py
@@ -181,6 +181,7 @@ class GRPCWebRTCBridge:
                     last_freq_counter,
                     last_freq_update,
                     thread_cancel,
+                    session.session_id,
                 ),
                 daemon=True,
             ).start()
@@ -235,6 +236,9 @@ class GRPCWebRTCBridge:
         self._thread_bus_calls.join()
         await self.producer.close()
 
+    def abort_session(self, session_id: str) -> None:
+        asyncio.run_coroutine_threadsafe(self.producer.close_session(session_id), self.producer._asyncloop)
+
     # Handle service request
     async def handle_service_request(
         self,
@@ -248,7 +252,13 @@ class GRPCWebRTCBridge:
         self.logger.debug(f"Received service request message: {request}")
 
         if request.HasField("get_reachy"):
-            resp = await self.handle_get_reachy_request(grpc_client)
+            try:
+                resp = await self.handle_get_reachy_request(grpc_client)
+            except Exception as e:
+                self.logger.error(f"Error while handling get_reachy request: {e}. Aborting session")
+                await grpc_client.close()
+                self.abort_session(session.session_id)
+
             byte_data = resp.SerializeToString()
             gbyte_data = GLib.Bytes.new(byte_data)
             data_channel.send_data(gbyte_data)
@@ -540,6 +550,7 @@ class GRPCWebRTCBridge:
         last_freq_counter: Dict[str, int],
         last_freq_update: Dict[str, float],
         thread_cancel: Event,
+        session_id: str,
     ) -> None:
         while not thread_cancel.is_set():
             try:
@@ -549,6 +560,7 @@ class GRPCWebRTCBridge:
                 time.sleep(0.001)
             except Exception as e:
                 self.logger.error(f"Error while handling {part_name} commands: {e}")
+                self.abort_session(session_id)
         self.logger.debug(f"Thread {part_name} closed")
 
     def handle_important_queue_routine(


### PR DESCRIPTION
The bridge should be more resilient in case of failure of the core:
- if the core is not started it will close the webrtc session after 20sec (and Unity will automatically re-ask for a session)
- if the core fails during streaming, the session will be close as well. Note that Unity can reconnect during teleoperation, but we need to go back to the mirror scene in order to properly re-enter the teleop and send the turn on commands (the core being restarted Reachy motors should be off)

Can be tested in dev mode. Requires this branch https://github.com/pollen-robotics/gst-signalling-py/tree/53-emit-end-of-session